### PR TITLE
Amazon Sagemaker fails to extract the archived model.tar.gz

### DIFF
--- a/run_local/download_hf_model.py
+++ b/run_local/download_hf_model.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
         repo_id=args.repo_id,
         cache_dir=args.cache_dir,
         revision=args.revision,
+        local_dir_use_symlinks=False
         allow_regex=args.allow_regex,
         ignore_regex=args.ignore_regex
     )

--- a/run_local/download_hf_model.py
+++ b/run_local/download_hf_model.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser("Convenience script for downloading models from HF hub.")
 
     parser.add_argument('repo_id', type=str, help='Repo id')
-    parser.add_argument('--cache_dir', type=str, default='./run_local/test_dir/', help='cache directory')
+    parser.add_argument('--local_dir', type=str, default='./run_local/test_dir/', help='local directory')
     parser.add_argument('--revision', type=str, default='main', help='revision')
     parser.add_argument('--allow_regex', type=str, nargs='+', default=None, help='space delim string')
     parser.add_argument('--ignore_regex', type=str, nargs='+', default=None, help='space delim string')
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     
     snapshot_download(
         repo_id=args.repo_id,
-        cache_dir=args.cache_dir,
+        local_dir=args.local_dir,
         revision=args.revision,
         local_dir_use_symlinks=False
         allow_regex=args.allow_regex,


### PR DESCRIPTION
Amazon Sagemaker fails to extract the archived model.tar.gz for the following reason:

> Failed to extract model data archive for container
> SageMaker expects a TAR file with the model data for use in your endpoint. After SageMaker downloads the TAR file, the data archive is extracted. This error might occur if SageMaker can't extract this data archive. For example, SageMaker can't extract the data archive if the model artifact contains symbolic links for files located in the TAR file.
> 
> When you create an endpoint, make sure that the model artifacts don't include symbolic links within the TAR file. To check if the TAR file includes symbolic links, extract the model data, and then run the following command inside the artifacts:
> 
> find . -type l -ls
> This command returns all the symbolic links found after searching through the current directory and any of its subdirectories. Replace any link that's returned with the actual copies of the file.
> 
Ref: [https://repost.aws/knowledge-center/sagemaker-endpoint-creation-fail]()

Added Changes:

- Changed **cache_dir** to **local_dir** so the actual files are download, using cache_dir downloads blobs and then symlinks the files with those blobs which creates a tar.gz unrecognised by AWS sagemaker
- Set **local_dir_use_symlinks=False** so no files are symbolic linked which may lead to failed model extraction.